### PR TITLE
fix: disable SQL logging, fix withdraw balance check, stop AutoOrder …

### DIFF
--- a/electron/main/database.ts
+++ b/electron/main/database.ts
@@ -21,7 +21,7 @@ if (!fs.existsSync(userDataPath))
 
 export const dbPath = path.join(userDataPath, config.dbFilePath)
 console.log('SQLite path:', dbPath)
-export const db = new Database(dbPath, { verbose: console.log })
+export const db = new Database(dbPath)
 
 // INITIALIZE DATABASE SCHEMA
 // Initialize wallets table if it doesn't exist

--- a/electron/main/handlers/orderHandler.ts
+++ b/electron/main/handlers/orderHandler.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from 'electron'
 import { getCurrentInstance } from '../utils/coreReloader'
+import { getFeeRatio } from '@thesingularitynetwork/darkswap-sdk'
+import { getDarkSwap } from '../../core/utils/darkSwap'
 
 export const registerOrderHandlers = () => {
   ipcMain.handle('order:createOrder', async (event, orderDto) => {
@@ -87,6 +89,17 @@ export const registerOrderHandlers = () => {
       return await dbInstance
         .getOrderManager()
         .getOrderEventsByPage(chainId, page, limit, sort, status, search)
+    }
+  )
+
+  // getFeeRatio from DarkSwapFeeManager contract
+  ipcMain.handle(
+    'order:getFeeRatio',
+    async (event, chainId: number, wallet: string) => {
+      const dbInstance = getCurrentInstance()
+      const [signer] = dbInstance.getRpcManager().getSignerAndPublicKey(wallet, chainId)
+      const darkSwap = getDarkSwap(chainId, signer)
+      return await getFeeRatio(wallet, darkSwap)
     }
   )
 }

--- a/electron/main/utils/coreReloader.ts
+++ b/electron/main/utils/coreReloader.ts
@@ -154,9 +154,6 @@ export async function reloadCore(
 
     // Start services
     try {
-      currentInstance.getAutoOrderManager().start()
-      console.log('Auto order manager started')
-
       if (apiKey) {
         currentInstance.getWebSocketClient().startWebSocket()
         currentInstance.getAssetPairService().syncAssetPairs()
@@ -195,8 +192,6 @@ export function getOrCreateCoreInstance(
 
     // Start services
     try {
-      currentInstance.getAutoOrderManager().start()
-
       if (apiKey) {
         currentInstance.getWebSocketClient().startWebSocket()
         currentInstance.getAssetPairService().syncAssetPairs()

--- a/electron/preload/preload.ts
+++ b/electron/preload/preload.ts
@@ -103,7 +103,9 @@ contextBridge.exposeInMainWorld('orderAPI', {
       sort,
       status,
       search
-    )
+    ),
+  getFeeRatio: (chainId: number, wallet: string) =>
+    ipcRenderer.invoke('order:getFeeRatio', chainId, wallet)
 })
 
 // Auto order APIs

--- a/renderer/components/Form/LimitOrderForm.tsx
+++ b/renderer/components/Form/LimitOrderForm.tsx
@@ -53,12 +53,17 @@ export const LimitOrderForm: React.FC<LimitOrderFormProps> = ({ onClose }) => {
   })
   const [marketPrice, setMarketPrice] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
+  const [feeRatio, setFeeRatio] = useState<string>('')
 
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!chainId || !selectedAccount) return
     fetchAssets(chainId, selectedAccount.address)
+    // @ts-ignore
+    window.orderAPI.getFeeRatio(chainId, selectedAccount.address)
+      .then((ratio: any) => setFeeRatio(ratio?.toString() ?? ''))
+      .catch(() => setFeeRatio(''))
   }, [selectedAccount, chainId])
 
   const balanceTokenOut = useMemo(() => {
@@ -192,7 +197,7 @@ export const LimitOrderForm: React.FC<LimitOrderFormProps> = ({ onClose }) => {
         amountOut: amountOutBN,
         amountIn: amountInBN,
         partialAmountIn: partialAmountInBN,
-        feeRatio: '0.001'
+        feeRatio: feeRatio || '0.001'
       }
 
       console.log('Placing order with params:', params)
@@ -223,6 +228,19 @@ export const LimitOrderForm: React.FC<LimitOrderFormProps> = ({ onClose }) => {
       amountOut: ''
     }))
   }
+
+  const serviceFeeDisplay = useMemo(() => {
+    if (!feeRatio || !formData.amountIn || !formData.assetIn) return '--'
+    try {
+      const amountBN = ethers.parseUnits(formData.amountIn, formData.assetIn.decimals)
+      const ratioBN = BigInt(feeRatio)
+      const precision = BigInt(1000000)
+      const feeAmount = (amountBN * ratioBN + precision - 1n) / precision
+      return `${ethers.formatUnits(feeAmount, formData.assetIn.decimals)} ${formData.assetIn.symbol}`
+    } catch {
+      return '--'
+    }
+  }, [feeRatio, formData.amountIn, formData.assetIn])
 
   const btnDisabled =
     !formData.amountOut || !formData.price || loading || !!error
@@ -383,7 +401,7 @@ export const LimitOrderForm: React.FC<LimitOrderFormProps> = ({ onClose }) => {
             variant='body1'
             color='#BDC1CA'
           >
-            1 USDC
+            {serviceFeeDisplay}
           </Typography>
         </Stack>
         <Stack

--- a/renderer/components/Form/TriggerOrderForm.tsx
+++ b/renderer/components/Form/TriggerOrderForm.tsx
@@ -62,10 +62,15 @@ export const TriggerOrderForm: React.FC<TriggerOrderFormProps> = ({
   const [loading, setLoading] = useState(false)
   const [marketPrice, setMarketPrice] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
+  const [feeRatio, setFeeRatio] = useState<string>('')
 
   useEffect(() => {
     if (!chainId || !selectedAccount) return
     fetchAssets(chainId, selectedAccount.address)
+    // @ts-ignore
+    window.orderAPI.getFeeRatio(chainId, selectedAccount.address)
+      .then((ratio: any) => setFeeRatio(ratio?.toString() ?? ''))
+      .catch(() => setFeeRatio(''))
   }, [selectedAccount, chainId])
 
   const balanceTokenOut = useMemo(() => {
@@ -203,7 +208,7 @@ export const TriggerOrderForm: React.FC<TriggerOrderFormProps> = ({
         amountIn: amountInBN,
         partialAmountIn: partialAmountInBN,
         orderTriggerPrice: formData.triggerPrice,
-        feeRatio: '0.001'
+        feeRatio: feeRatio || '0.001'
       }
 
       console.log('Placing order with params:', params)
@@ -244,6 +249,19 @@ export const TriggerOrderForm: React.FC<TriggerOrderFormProps> = ({
       fetchMarketPrice(assetPair)
     }
   }
+
+  const serviceFeeDisplay = useMemo(() => {
+    if (!feeRatio || !formData.amountIn || !formData.assetIn) return '--'
+    try {
+      const amountBN = ethers.parseUnits(formData.amountIn, formData.assetIn.decimals)
+      const ratioBN = BigInt(feeRatio)
+      const precision = BigInt(1000000)
+      const feeAmount = (amountBN * ratioBN + precision - 1n) / precision
+      return `${ethers.formatUnits(feeAmount, formData.assetIn.decimals)} ${formData.assetIn.symbol}`
+    } catch {
+      return '--'
+    }
+  }, [feeRatio, formData.amountIn, formData.assetIn])
 
   const btnDisabled =
     !formData.amountOut ||
@@ -453,7 +471,7 @@ export const TriggerOrderForm: React.FC<TriggerOrderFormProps> = ({
             variant='body1'
             color='#BDC1CA'
           >
-            1 USDC
+            {serviceFeeDisplay}
           </Typography>
         </Stack>
         <Stack

--- a/renderer/components/Modal/WithdrawModal.tsx
+++ b/renderer/components/Modal/WithdrawModal.tsx
@@ -113,7 +113,7 @@ export const WithdrawModal = ({
     !data.amount ||
     loading ||
     Number(data.amount) === 0 ||
-    data.amount > balanceToken ||
+    Number(data.amount) > Number(balanceToken) ||
     error !== null
 
   useEffect(() => {


### PR DESCRIPTION
…auto-start, dynamic service fee

1. Remove verbose SQL logging from better-sqlite3 Database constructor
2. Fix string comparison bug in WithdrawModal — use Number() for balance check
3. Remove autoOrderManager.start() from coreReloader to prevent auto-start on boot
4. Fetch service fee from DarkSwapFeeManager contract via SDK getFeeRatio instead of hardcoded "1 USDC", display computed fee amount in the in-asset token