### PR TITLE
fix: syncAssets missing parameter, add token icons, remove debug logs

### DIFF
--- a/electron/core/common/db/database.service.ts
+++ b/electron/core/common/db/database.service.ts
@@ -215,7 +215,8 @@ export class DatabaseService {
       walletAddress.toLowerCase(),
       chainId,
       NoteStatus.ACTIVE,
-      NoteStatus.CREATED
+      NoteStatus.CREATED,
+      NoteStatus.LOCKED
     ) as NoteEntity[]
 
     const notes = rows.map((row) => ({

--- a/electron/main/database.ts
+++ b/electron/main/database.ts
@@ -62,8 +62,6 @@ const configs = db.prepare('SELECT * FROM configs').all() as Array<{
   value: string
 }>
 
-console.log('Loaded wallets from DB:', wallets)
-console.log('Loaded configs from DB:', configs)
 
 const apiKey = configs.find((c) => c.key === 'api_key')?.value || ''
 

--- a/electron/main/handlers/assetPairHandler.ts
+++ b/electron/main/handlers/assetPairHandler.ts
@@ -37,7 +37,13 @@ export const registerAssetPairHandlers = () => {
         quoteDecimal: number
       }>
 
-    const tokenMap = new Map<string, { address: string; symbol: string; name: string; decimals: number }>()
+    const knownLogos: Record<string, string> = {
+      ETH: '/tokens/ETH.png',
+      USDC: '/tokens/USDC.png',
+      USDT: '/tokens/USDT.png'
+    }
+
+    const tokenMap = new Map<string, { address: string; symbol: string; name: string; decimals: number; logoURI?: string }>()
 
     for (const pair of assetPairs) {
       const baseKey = pair.baseAddress.toLowerCase()
@@ -46,7 +52,8 @@ export const registerAssetPairHandlers = () => {
           address: pair.baseAddress,
           symbol: pair.baseSymbol,
           name: pair.baseSymbol,
-          decimals: pair.baseDecimal
+          decimals: pair.baseDecimal,
+          logoURI: knownLogos[pair.baseSymbol]
         })
       }
 
@@ -56,7 +63,8 @@ export const registerAssetPairHandlers = () => {
           address: pair.quoteAddress,
           symbol: pair.quoteSymbol,
           name: pair.quoteSymbol,
-          decimals: pair.quoteDecimal
+          decimals: pair.quoteDecimal,
+          logoURI: knownLogos[pair.quoteSymbol]
         })
       }
     }


### PR DESCRIPTION
1. Fix RangeError in getNotesByWalletAndChainId — query has 5 placeholders but only 4 values were provided; add missing NoteStatus.LOCKED parameter
2. Add logoURI for ETH/USDC/USDT tokens using local PNG files in public/tokens/
3. Remove console.log for wallets and configs on startup