### PR TITLE
feat(settings,security): add RPC URL settings submenu and Electron CSP

### DIFF
--- a/electron/main/csp.ts
+++ b/electron/main/csp.ts
@@ -1,0 +1,28 @@
+/**
+ * Content-Security-Policy header generation for Electron BrowserWindow.
+ *
+ * Dev CSP:  allows localhost:3000, ws://, wss://, unsafe-inline for MUI/emotion.
+ * Prod CSP: allows app://, wss://, unsafe-inline for styles, no unsafe-eval.
+ */
+
+export function buildCsp(isDev: boolean): string {
+  if (isDev) {
+    return [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' data:",
+      "img-src 'self' data: https:",
+      "connect-src 'self' http://localhost:3000 ws://localhost:3000 ws: wss: https:",
+    ].join('; ')
+  }
+
+  return [
+    "default-src 'self' app:",
+    "script-src 'self' app:",
+    "style-src 'self' 'unsafe-inline' app:",
+    "font-src 'self' data: app:",
+    "img-src 'self' data: https: app:",
+    "connect-src 'self' app: ws: wss: https:",
+  ].join('; ')
+}

--- a/electron/main/handlers/configHandler.ts
+++ b/electron/main/handlers/configHandler.ts
@@ -53,6 +53,44 @@ export function registerConfigHandlers() {
     }
   )
 
+  // RPC URL overlay: DB custom value > yaml fallback
+  ipcMain.handle('config:getRpcUrl', async (_event, chainId: number) => {
+    const dbRow = db
+      .prepare('SELECT value FROM configs WHERE key = ?')
+      .get(`rpc_url_${chainId}`) as { value: string } | undefined
+
+    if (dbRow) {
+      return { rpcUrl: dbRow.value, isCustom: true }
+    }
+
+    const yamlEntry = config?.chainRpcs?.find(
+      (r: { chainId: number; rpcUrl: string }) => r.chainId === chainId
+    )
+    if (yamlEntry) {
+      return { rpcUrl: yamlEntry.rpcUrl, isCustom: false }
+    }
+
+    return { rpcUrl: '', isCustom: false }
+  })
+
+  ipcMain.handle(
+    'config:setRpcUrl',
+    async (_event, chainId: number, rpcUrl: string) => {
+      const stmt = db.prepare(
+        'INSERT OR REPLACE INTO configs (key, value) VALUES (?, ?)'
+      )
+      stmt.run(`rpc_url_${chainId}`, rpcUrl)
+      await reloadCore(db, dbPath)
+      return { success: true }
+    }
+  )
+
+  ipcMain.handle('config:resetRpcUrl', async (_event, chainId: number) => {
+    db.prepare('DELETE FROM configs WHERE key = ?').run(`rpc_url_${chainId}`)
+    await reloadCore(db, dbPath)
+    return { success: true }
+  })
+
   // Heathcheck config handler
   ipcMain.handle('config:healthCheck', async (event, apiKey: string) => {
     try {

--- a/electron/main/main.ts
+++ b/electron/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, session } from 'electron'
 import * as path from 'path'
 import serve from 'electron-serve'
 import { registerAccountHandlers } from './handlers/accountHandler'
@@ -8,6 +8,7 @@ import { registerRPCManagerHandlers } from './handlers/rpcManagerHandler'
 import { registerConfigHandlers } from './handlers/configHandler'
 import { registerAppHandlers } from './handlers/appHandler'
 import { registerAutoOrderHandlers } from './handlers/autoOrderHandler'
+import { buildCsp } from './csp'
 
 const appServe = app.isPackaged
   ? serve({ directory: path.join(__dirname, '../../renderer/out') })
@@ -25,7 +26,19 @@ async function createWindow() {
     autoHideMenuBar: true
   })
 
-  if (process.env.NODE_ENV === 'development') {
+  const isDev = process.env.NODE_ENV === 'development'
+  const cspHeader = buildCsp(isDev)
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [cspHeader],
+      },
+    })
+  })
+
+  if (isDev) {
     await mainWindow.loadURL('http://localhost:3000')
     mainWindow.webContents.openDevTools()
   } else {

--- a/electron/main/utils/coreReloader.ts
+++ b/electron/main/utils/coreReloader.ts
@@ -1,4 +1,4 @@
-import { DarkSwapClientCore, DarkSwapConfig } from '../../core'
+import { DarkSwapClientCore, DarkSwapConfig, ChainRpcConfig } from '../../core'
 import { Database } from 'better-sqlite3'
 
 import { ipcMain } from 'electron'
@@ -38,6 +38,41 @@ export function initializeCoreReloader(options: CoreReloaderOptions) {
 }
 
 /**
+ * Merge yaml chainRpcs with DB rpc_url_* overrides.
+ * DB keys follow the pattern rpc_url_{chainId} (e.g. rpc_url_8453).
+ * When a DB override exists for a chainId, its value replaces the yaml rpcUrl.
+ */
+function mergeChainRpcsWithDbOverrides(
+  db: Database,
+  yamlChainRpcs: ChainRpcConfig[]
+): ChainRpcConfig[] {
+  const dbRpcConfigs = db
+    .prepare("SELECT key, value FROM configs WHERE key LIKE 'rpc_url_%'")
+    .all() as Array<{ key: string; value: string }>
+
+  if (dbRpcConfigs.length === 0) {
+    return yamlChainRpcs
+  }
+
+  const overrideMap = new Map<number, string>()
+  for (const row of dbRpcConfigs) {
+    const chainIdStr = row.key.replace('rpc_url_', '')
+    const chainId = Number(chainIdStr)
+    if (!Number.isNaN(chainId) && row.value) {
+      overrideMap.set(chainId, row.value)
+    }
+  }
+
+  return yamlChainRpcs.map((entry) => {
+    const override = overrideMap.get(entry.chainId)
+    if (override) {
+      return { ...entry, rpcUrl: override }
+    }
+    return entry
+  })
+}
+
+/**
  * Create a new DarkSwapClientCore instance with current config and wallets
  */
 function createCoreInstance(
@@ -61,7 +96,7 @@ function createCoreInstance(
 
   const darkSwapConfig: DarkSwapConfig = {
     wallets: [...(latestConfig.wallets || []), ...dbWallets],
-    chainRpcs: latestConfig.chainRpcs || [],
+    chainRpcs: mergeChainRpcsWithDbOverrides(db, latestConfig.chainRpcs || []),
     dbFilePath: dbPath,
     bookNodeSocketUrl:
       latestConfig.bookNodeSocketUrl || 'wss://socket.darknode.io',
@@ -136,7 +171,7 @@ export async function reloadCore(
     // Create updated config with fresh file config + db wallets
     const updatedConfig: DarkSwapConfig = {
       wallets: [...(latestConfig.wallets || []), ...dbWallets],
-      chainRpcs: latestConfig.chainRpcs || [],
+      chainRpcs: mergeChainRpcsWithDbOverrides(db, latestConfig.chainRpcs || []),
       dbFilePath: dbPath,
       bookNodeSocketUrl:
         latestConfig.bookNodeSocketUrl || 'wss://socket.darknode.io',

--- a/electron/preload/preload.ts
+++ b/electron/preload/preload.ts
@@ -170,7 +170,13 @@ contextBridge.exposeInMainWorld('configAPI', {
   setConfigs: (configs: { [key: string]: string }) =>
     ipcRenderer.invoke('config:setConfigs', configs),
   healthCheck: (apiKey: string) =>
-    ipcRenderer.invoke('config:healthCheck', apiKey)
+    ipcRenderer.invoke('config:healthCheck', apiKey),
+  getRpcUrl: (chainId: number) =>
+    ipcRenderer.invoke('config:getRpcUrl', chainId),
+  setRpcUrl: (chainId: number, rpcUrl: string) =>
+    ipcRenderer.invoke('config:setRpcUrl', chainId, rpcUrl),
+  resetRpcUrl: (chainId: number) =>
+    ipcRenderer.invoke('config:resetRpcUrl', chainId)
 })
 
 // Core APIs

--- a/renderer/components/SettingContent/ApiKeySettings.tsx
+++ b/renderer/components/SettingContent/ApiKeySettings.tsx
@@ -1,0 +1,214 @@
+import { VisibilityOff, Visibility } from '@mui/icons-material'
+import {
+  Button,
+  IconButton,
+  InputBase,
+  Stack,
+  Tooltip,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import SaveIcon from '@mui/icons-material/Save'
+import { useConfigContext } from '../../contexts/ConfigContext/hooks'
+import InfoOutlineIcon from '@mui/icons-material/InfoOutline'
+import CheckIcon from '@mui/icons-material/Check'
+import CloseIcon from '@mui/icons-material/Close'
+import { WarningAlert } from '../Alert'
+
+export const ApiKeySettings = () => {
+  const [formConfig, setFormConfig] = useState<{ apiKey?: string }>({})
+  const { apiKey, saveConfigs } = useConfigContext()
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [verified, setVerified] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    setFormConfig({ apiKey })
+  }, [apiKey])
+
+  const onChangeApiKey = (value: string) => {
+    setFormConfig((prev) => ({ ...prev, apiKey: value }))
+  }
+
+  const onSaveChanges = async () => {
+    await saveConfigs({ api_key: formConfig.apiKey || '' })
+    setVerified(null)
+  }
+
+  const onDiscardChanges = () => {
+    setFormConfig({ apiKey })
+    setVerified(null)
+  }
+
+  const onClearApiKey = () => {
+    setFormConfig((prev) => ({ ...prev, apiKey: '' }))
+    setVerified(null)
+  }
+
+  const onVerifyApiKey = async () => {
+    if (!formConfig.apiKey) return
+    setLoading(true)
+    setVerified(null)
+    try {
+      // @ts-ignore
+      const result = await window.configAPI.healthCheck(formConfig.apiKey)
+      console.log('health check result', result)
+      if (result.healthy) {
+        setVerified(true)
+      } else {
+        setVerified(false)
+      }
+    } catch (error) {
+      console.error('Error verifying API key:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Stack mt={5}>
+      <Stack width={600}>
+        <Stack
+          direction='row'
+          spacing={2}
+          alignItems='center'
+          justifyContent={'space-between'}
+        >
+          <Tooltip
+            title={`
+            Please enter your API key. You can get it from registration page.
+            Notice: The API key is required to connect to the server.`}
+            arrow
+          >
+            <Typography color='white'>
+              Your API key{' '}
+              <InfoOutlineIcon sx={{ color: 'white', fontSize: 16 }} />:
+            </Typography>
+          </Tooltip>
+
+          <Stack
+            direction='row'
+            spacing={2}
+            alignItems='center'
+          >
+            <Stack
+              direction={'row'}
+              alignItems='center'
+              spacing={1}
+              sx={{
+                borderBottom: `1px solid ${
+                  verified === null ? 'white' : verified ? '#68EB8E' : '#FF6B6B'
+                }`
+              }}
+            >
+              <InputBase
+                type={showApiKey ? 'text' : 'password'}
+                value={formConfig.apiKey || ''}
+                onChange={(e) => onChangeApiKey(e.target.value)}
+                sx={{
+                  width: '300px',
+                  color:
+                    verified === null
+                      ? 'white'
+                      : verified
+                      ? '#68EB8E'
+                      : '#FF6B6B'
+                }}
+              />
+              {showApiKey ? (
+                <VisibilityOff
+                  sx={{
+                    color:
+                      verified === null
+                        ? 'white'
+                        : verified
+                        ? '#68EB8E'
+                        : '#FF6B6B',
+                    cursor: 'pointer'
+                  }}
+                  onClick={() => setShowApiKey(false)}
+                />
+              ) : (
+                <Visibility
+                  sx={{
+                    color:
+                      verified === null
+                        ? 'white'
+                        : verified
+                        ? '#68EB8E'
+                        : '#FF6B6B',
+                    cursor: 'pointer'
+                  }}
+                  onClick={() => setShowApiKey(true)}
+                />
+              )}
+            </Stack>
+            {!verified ? (
+              verified === null ? (
+                <Button
+                  size='small'
+                  variant='contained'
+                  sx={{
+                    background: '#68EB8E',
+                    color: '#0A0A0A',
+
+                    '&.Mui-disabled': {
+                      border: 'none',
+                      background: 'inherit'
+                    },
+
+                    '& .MuiCircularProgress-root': {
+                      color: '#68EB8E'
+                    }
+                  }}
+                  onClick={onVerifyApiKey}
+                  loading={loading}
+                >
+                  Verify
+                </Button>
+              ) : (
+                <IconButton onClick={onClearApiKey}>
+                  <CloseIcon sx={{ color: '#FF6B6B' }} />
+                </IconButton>
+              )
+            ) : (
+              <CheckIcon sx={{ color: '#68EB8E' }} />
+            )}
+          </Stack>
+        </Stack>
+
+        <WarningAlert text='Each API key is bound to one desktop app. Using the same wallet with multiple API keys on different desktops may cause errors.' />
+      </Stack>
+      {/* Button group */}
+      <Stack
+        mt={4}
+        spacing={2}
+        direction='row'
+      >
+        <Button
+          variant='outlined'
+          sx={{
+            border: '1px solid #68EB8E',
+            color: '#68EB8E'
+          }}
+          onClick={onDiscardChanges}
+          disabled={loading}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant='contained'
+          sx={{
+            background: '#68EB8E',
+            color: '#0A0A0A'
+          }}
+          startIcon={<SaveIcon />}
+          onClick={onSaveChanges}
+          disabled={loading || !verified}
+        >
+          Save Changes
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/renderer/components/SettingContent/RpcUrlSettings.tsx
+++ b/renderer/components/SettingContent/RpcUrlSettings.tsx
@@ -1,0 +1,187 @@
+import {
+  Button,
+  CircularProgress,
+  InputBase,
+  Stack,
+  Typography
+} from '@mui/material'
+import { useContext, useEffect, useState, useCallback } from 'react'
+import { ChainContext } from '../../contexts/ChainContext/ChainProvider'
+
+export const RpcUrlSettings = () => {
+  const { currentChain } = useContext(ChainContext)
+  const [rpcUrl, setRpcUrl] = useState('')
+  const [isCustom, setIsCustom] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const fetchRpcUrl = useCallback(async (chainId: number) => {
+    try {
+      // @ts-ignore
+      const result = await window.configAPI.getRpcUrl(chainId)
+      setRpcUrl(result.rpcUrl)
+      setIsCustom(result.isCustom)
+      setError(null)
+    } catch (err) {
+      console.error('Error fetching RPC URL:', err)
+      setError('Failed to load RPC URL')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (currentChain?.chainId) {
+      fetchRpcUrl(currentChain.chainId)
+    }
+  }, [currentChain?.chainId, fetchRpcUrl])
+
+  const validateUrl = (url: string): boolean => {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }
+
+  const onSave = async () => {
+    if (!currentChain?.chainId) return
+
+    if (!validateUrl(rpcUrl)) {
+      setError('Invalid URL. Must start with http:// or https://')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      // @ts-ignore
+      const result = await window.configAPI.setRpcUrl(currentChain.chainId, rpcUrl)
+      if (result.success) {
+        await fetchRpcUrl(currentChain.chainId)
+      } else {
+        setError('Failed to save RPC URL')
+      }
+    } catch (err) {
+      console.error('Error saving RPC URL:', err)
+      setError('Failed to save RPC URL')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const onReset = async () => {
+    if (!currentChain?.chainId) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      // @ts-ignore
+      const result = await window.configAPI.resetRpcUrl(currentChain.chainId)
+      if (result.success) {
+        await fetchRpcUrl(currentChain.chainId)
+      } else {
+        setError('Failed to reset RPC URL')
+      }
+    } catch (err) {
+      console.error('Error resetting RPC URL:', err)
+      setError('Failed to reset RPC URL')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!currentChain) {
+    return (
+      <Stack mt={5}>
+        <Typography color='white'>No chain selected</Typography>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack mt={5}>
+      <Stack width={600}>
+        <Typography color='white' sx={{ mb: 3, fontSize: '1rem' }}>
+          Current Chain: {currentChain.name} ({currentChain.chainId})
+        </Typography>
+
+        <Typography color='white' sx={{ mb: 1 }}>
+          RPC URL:
+        </Typography>
+
+        <Stack
+          sx={{
+            borderBottom: `1px solid ${error ? '#FF6B6B' : 'white'}`
+          }}
+        >
+          <InputBase
+            value={rpcUrl}
+            onChange={(e) => {
+              setRpcUrl(e.target.value)
+              setError(null)
+            }}
+            placeholder='https://...'
+            disabled={loading}
+            sx={{
+              width: '100%',
+              color: error ? '#FF6B6B' : 'white'
+            }}
+          />
+        </Stack>
+
+        <Typography
+          sx={{
+            mt: 0.5,
+            fontSize: '0.8rem',
+            color: isCustom ? '#68EB8E' : 'rgba(255, 255, 255, 0.5)'
+          }}
+        >
+          {isCustom ? '(custom)' : '(default)'}
+        </Typography>
+
+        {error && (
+          <Typography
+            sx={{
+              mt: 1,
+              fontSize: '0.85rem',
+              color: '#FF6B6B'
+            }}
+          >
+            {error}
+          </Typography>
+        )}
+      </Stack>
+
+      <Stack mt={4} spacing={2} direction='row'>
+        {isCustom && (
+          <Button
+            variant='outlined'
+            sx={{
+              border: '1px solid #68EB8E',
+              color: '#68EB8E'
+            }}
+            onClick={onReset}
+            disabled={loading}
+          >
+            {loading ? <CircularProgress size={20} sx={{ color: '#68EB8E' }} /> : 'Reset to Default'}
+          </Button>
+        )}
+        <Button
+          variant='contained'
+          sx={{
+            background: '#68EB8E',
+            color: '#0A0A0A',
+            '&.Mui-disabled': {
+              border: 'none',
+              background: 'inherit'
+            }
+          }}
+          onClick={onSave}
+          disabled={loading}
+        >
+          {loading ? <CircularProgress size={20} sx={{ color: '#68EB8E' }} /> : 'Save'}
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/renderer/components/SettingContent/index.tsx
+++ b/renderer/components/SettingContent/index.tsx
@@ -1,214 +1,45 @@
-import { VisibilityOff, Visibility } from '@mui/icons-material'
-import {
-  Button,
-  IconButton,
-  InputBase,
-  Stack,
-  Tooltip,
-  Typography
-} from '@mui/material'
-import { useEffect, useState } from 'react'
-import SaveIcon from '@mui/icons-material/Save'
-import { useConfigContext } from '../../contexts/ConfigContext/hooks'
-import InfoOutlineIcon from '@mui/icons-material/InfoOutline'
-import CheckIcon from '@mui/icons-material/Check'
-import CloseIcon from '@mui/icons-material/Close'
-import { WarningAlert } from '../Alert'
+import { Box, Tab, Tabs } from '@mui/material'
+import { useState, SyntheticEvent } from 'react'
+import { ApiKeySettings } from './ApiKeySettings'
+import { RpcUrlSettings } from './RpcUrlSettings'
 
 export const SettingContent = () => {
-  const [formConfig, setFormConfig] = useState<{ apiKey?: string }>({})
-  const { apiKey, saveConfigs } = useConfigContext()
-  const [showApiKey, setShowApiKey] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [verified, setVerified] = useState<boolean | null>(null)
+  const [activeTab, setActiveTab] = useState(0)
 
-  useEffect(() => {
-    setFormConfig({ apiKey })
-  }, [apiKey])
-
-  const onChangeApiKey = (value: string) => {
-    setFormConfig((prev) => ({ ...prev, apiKey: value }))
-  }
-
-  const onSaveChanges = async () => {
-    await saveConfigs({ api_key: formConfig.apiKey || '' })
-    setVerified(null)
-  }
-
-  const onDiscardChanges = () => {
-    setFormConfig({ apiKey })
-    setVerified(null)
-  }
-
-  const onClearApiKey = () => {
-    setFormConfig((prev) => ({ ...prev, apiKey: '' }))
-    setVerified(null)
-  }
-
-  const onVerifyApiKey = async () => {
-    if (!formConfig.apiKey) return
-    setLoading(true)
-    setVerified(null)
-    try {
-      // @ts-ignore
-      const result = await window.configAPI.healthCheck(formConfig.apiKey)
-      console.log('health check result', result)
-      if (result.healthy) {
-        setVerified(true)
-      } else {
-        setVerified(false)
-      }
-    } catch (error) {
-      console.error('Error verifying API key:', error)
-    } finally {
-      setLoading(false)
-    }
+  const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue)
   }
 
   return (
-    <Stack mt={5}>
-      <Stack width={600}>
-        <Stack
-          direction='row'
-          spacing={2}
-          alignItems='center'
-          justifyContent={'space-between'}
-        >
-          <Tooltip
-            title={`
-            Please enter your API key. You can get it from registration page. 
-            Notice: The API key is required to connect to the server.`}
-            arrow
-          >
-            <Typography color='white'>
-              Your API key{' '}
-              <InfoOutlineIcon sx={{ color: 'white', fontSize: 16 }} />:
-            </Typography>
-          </Tooltip>
-
-          <Stack
-            direction='row'
-            spacing={2}
-            alignItems='center'
-          >
-            <Stack
-              direction={'row'}
-              alignItems='center'
-              spacing={1}
-              sx={{
-                borderBottom: `1px solid ${
-                  verified === null ? 'white' : verified ? '#68EB8E' : '#FF6B6B'
-                }`
-              }}
-            >
-              <InputBase
-                type={showApiKey ? 'text' : 'password'}
-                value={formConfig.apiKey || ''}
-                onChange={(e) => onChangeApiKey(e.target.value)}
-                sx={{
-                  width: '300px',
-                  color:
-                    verified === null
-                      ? 'white'
-                      : verified
-                      ? '#68EB8E'
-                      : '#FF6B6B'
-                }}
-              />
-              {showApiKey ? (
-                <VisibilityOff
-                  sx={{
-                    color:
-                      verified === null
-                        ? 'white'
-                        : verified
-                        ? '#68EB8E'
-                        : '#FF6B6B',
-                    cursor: 'pointer'
-                  }}
-                  onClick={() => setShowApiKey(false)}
-                />
-              ) : (
-                <Visibility
-                  sx={{
-                    color:
-                      verified === null
-                        ? 'white'
-                        : verified
-                        ? '#68EB8E'
-                        : '#FF6B6B',
-                    cursor: 'pointer'
-                  }}
-                  onClick={() => setShowApiKey(true)}
-                />
-              )}
-            </Stack>
-            {!verified ? (
-              verified === null ? (
-                <Button
-                  size='small'
-                  variant='contained'
-                  sx={{
-                    background: '#68EB8E',
-                    color: '#0A0A0A',
-
-                    '&.Mui-disabled': {
-                      border: 'none',
-                      background: 'inherit'
-                    },
-
-                    '& .MuiCircularProgress-root': {
-                      color: '#68EB8E'
-                    }
-                  }}
-                  onClick={onVerifyApiKey}
-                  loading={loading}
-                >
-                  Verify
-                </Button>
-              ) : (
-                <IconButton onClick={onClearApiKey}>
-                  <CloseIcon sx={{ color: '#FF6B6B' }} />
-                </IconButton>
-              )
-            ) : (
-              <CheckIcon sx={{ color: '#68EB8E' }} />
-            )}
-          </Stack>
-        </Stack>
-
-        <WarningAlert text='Each API key is bound to one desktop app. Using the same wallet with multiple API keys on different desktops may cause errors.' />
-      </Stack>
-      {/* Button group */}
-      <Stack
-        mt={4}
-        spacing={2}
-        direction='row'
+    <Box sx={{ display: 'flex', mt: 3 }}>
+      <Tabs
+        orientation='vertical'
+        value={activeTab}
+        onChange={handleTabChange}
+        sx={{
+          minWidth: 160,
+          borderRight: '1px solid rgba(255, 255, 255, 0.12)',
+          '& .MuiTab-root': {
+            color: 'rgba(255, 255, 255, 0.7)',
+            alignItems: 'flex-start',
+            textTransform: 'none',
+            fontSize: '0.95rem',
+            '&.Mui-selected': {
+              color: '#68EB8E'
+            }
+          },
+          '& .MuiTabs-indicator': {
+            backgroundColor: '#68EB8E'
+          }
+        }}
       >
-        <Button
-          variant='outlined'
-          sx={{
-            border: '1px solid #68EB8E',
-            color: '#68EB8E'
-          }}
-          onClick={onDiscardChanges}
-          disabled={loading}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant='contained'
-          sx={{
-            background: '#68EB8E',
-            color: '#0A0A0A'
-          }}
-          startIcon={<SaveIcon />}
-          onClick={onSaveChanges}
-          disabled={loading || !verified}
-        >
-          Save Changes
-        </Button>
-      </Stack>
-    </Stack>
+        <Tab label='API Key' />
+        <Tab label='RPC URL' />
+      </Tabs>
+      <Box sx={{ flex: 1, pl: 3 }}>
+        {activeTab === 0 && <ApiKeySettings />}
+        {activeTab === 1 && <RpcUrlSettings />}
+      </Box>
+    </Box>
   )
 }

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -1,0 +1,91 @@
+import { buildCsp } from '../electron/main/csp'
+
+describe('buildCsp', () => {
+  describe('development mode', () => {
+    const csp = buildCsp(true)
+
+    it('allows localhost:3000 in connect-src', () => {
+      expect(csp).toContain('http://localhost:3000')
+      expect(csp).toContain('ws://localhost:3000')
+    })
+
+    it('allows ws: and wss: for WebSocket connections', () => {
+      expect(csp).toMatch(/connect-src[^;]*\bws:/)
+      expect(csp).toMatch(/connect-src[^;]*\bwss:/)
+    })
+
+    it('allows unsafe-inline for style-src (MUI/emotion)', () => {
+      expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/)
+    })
+
+    it('does not allow unsafe-eval anywhere', () => {
+      expect(csp).not.toContain('unsafe-eval')
+    })
+
+    it('does not include app: protocol', () => {
+      expect(csp).not.toContain('app:')
+    })
+
+    it('includes default-src self', () => {
+      expect(csp).toMatch(/default-src\s+'self'/)
+    })
+
+    it('includes script-src self without unsafe-eval', () => {
+      expect(csp).toMatch(/script-src\s+'self'/)
+      expect(csp).not.toMatch(/script-src[^;]*'unsafe-eval'/)
+    })
+
+    it('allows data: URIs for fonts and images', () => {
+      expect(csp).toMatch(/font-src[^;]*data:/)
+      expect(csp).toMatch(/img-src[^;]*data:/)
+    })
+
+    it('allows https: for connect-src and img-src', () => {
+      expect(csp).toMatch(/connect-src[^;]*https:/)
+      expect(csp).toMatch(/img-src[^;]*https:/)
+    })
+  })
+
+  describe('production mode', () => {
+    const csp = buildCsp(false)
+
+    it('allows app:// protocol in default-src', () => {
+      expect(csp).toMatch(/default-src[^;]*app:/)
+    })
+
+    it('allows app: in script-src', () => {
+      expect(csp).toMatch(/script-src[^;]*app:/)
+    })
+
+    it('allows app: in style-src', () => {
+      expect(csp).toMatch(/style-src[^;]*app:/)
+    })
+
+    it('allows unsafe-inline for style-src (MUI/emotion)', () => {
+      expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/)
+    })
+
+    it('does not allow unsafe-eval anywhere', () => {
+      expect(csp).not.toContain('unsafe-eval')
+    })
+
+    it('does not include localhost references', () => {
+      expect(csp).not.toContain('localhost')
+    })
+
+    it('allows ws: and wss: for WebSocket connections', () => {
+      expect(csp).toMatch(/connect-src[^;]*\bws:/)
+      expect(csp).toMatch(/connect-src[^;]*\bwss:/)
+    })
+
+    it('allows data: URIs for fonts and images', () => {
+      expect(csp).toMatch(/font-src[^;]*data:/)
+      expect(csp).toMatch(/img-src[^;]*data:/)
+    })
+
+    it('allows https: for connect-src and img-src', () => {
+      expect(csp).toMatch(/connect-src[^;]*https:/)
+      expect(csp).toMatch(/img-src[^;]*https:/)
+    })
+  })
+})

--- a/tests/rpcUrlConfig.test.ts
+++ b/tests/rpcUrlConfig.test.ts
@@ -1,0 +1,266 @@
+import Database from 'better-sqlite3'
+
+/**
+ * Reimplement the merge logic from coreReloader.ts for testing purposes.
+ * The original function is not exported, so we replicate the same DB query
+ * pattern and merge algorithm here.
+ */
+function mergeChainRpcsWithDbOverrides(
+  db: InstanceType<typeof Database>,
+  yamlChainRpcs: Array<{ chainId: number; rpcUrl: string }>
+): Array<{ chainId: number; rpcUrl: string }> {
+  const dbRpcConfigs = db
+    .prepare("SELECT key, value FROM configs WHERE key LIKE 'rpc_url_%'")
+    .all() as Array<{ key: string; value: string }>
+
+  if (dbRpcConfigs.length === 0) {
+    return yamlChainRpcs
+  }
+
+  const overrideMap = new Map<number, string>()
+  for (const row of dbRpcConfigs) {
+    const chainIdStr = row.key.replace('rpc_url_', '')
+    const chainId = Number(chainIdStr)
+    if (!Number.isNaN(chainId) && row.value) {
+      overrideMap.set(chainId, row.value)
+    }
+  }
+
+  return yamlChainRpcs.map((entry) => {
+    const override = overrideMap.get(entry.chainId)
+    return override ? { ...entry, rpcUrl: override } : entry
+  })
+}
+
+/**
+ * Reimplement the getRpcUrl IPC handler logic for testing purposes.
+ */
+function getRpcUrl(
+  db: InstanceType<typeof Database>,
+  yamlChainRpcs: Array<{ chainId: number; rpcUrl: string }>,
+  chainId: number
+): { rpcUrl: string; isCustom: boolean } {
+  const dbRow = db
+    .prepare('SELECT value FROM configs WHERE key = ?')
+    .get(`rpc_url_${chainId}`) as { value: string } | undefined
+
+  if (dbRow) {
+    return { rpcUrl: dbRow.value, isCustom: true }
+  }
+
+  const yamlEntry = yamlChainRpcs.find(
+    (r: { chainId: number; rpcUrl: string }) => r.chainId === chainId
+  )
+  if (yamlEntry) {
+    return { rpcUrl: yamlEntry.rpcUrl, isCustom: false }
+  }
+
+  return { rpcUrl: '', isCustom: false }
+}
+
+/**
+ * Reimplement the setRpcUrl IPC handler logic for testing purposes.
+ */
+function setRpcUrl(
+  db: InstanceType<typeof Database>,
+  chainId: number,
+  rpcUrl: string
+): { success: boolean } {
+  db.prepare('INSERT OR REPLACE INTO configs (key, value) VALUES (?, ?)').run(
+    `rpc_url_${chainId}`,
+    rpcUrl
+  )
+  return { success: true }
+}
+
+/**
+ * Reimplement the resetRpcUrl IPC handler logic for testing purposes.
+ */
+function resetRpcUrl(
+  db: InstanceType<typeof Database>,
+  chainId: number
+): { success: boolean } {
+  db.prepare('DELETE FROM configs WHERE key = ?').run(`rpc_url_${chainId}`)
+  return { success: true }
+}
+
+describe('RPC URL Config', () => {
+  let db: InstanceType<typeof Database>
+
+  const yamlChainRpcs = [
+    { chainId: 1, rpcUrl: 'https://eth-mainnet.example.com' },
+    { chainId: 8453, rpcUrl: 'https://base-mainnet.example.com' },
+    { chainId: 42161, rpcUrl: 'https://arbitrum-mainnet.example.com' },
+  ]
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS configs (id INTEGER PRIMARY KEY AUTOINCREMENT, key TEXT UNIQUE NOT NULL, value TEXT NOT NULL)'
+    )
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  describe('Overlay Merge Logic', () => {
+    test('returns yaml chainRpcs unchanged when no DB overrides exist', () => {
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+      expect(result).toEqual(yamlChainRpcs)
+    })
+
+    test('overrides yaml rpcUrl with DB value when rpc_url_{chainId} exists', () => {
+      db.prepare('INSERT INTO configs (key, value) VALUES (?, ?)').run(
+        'rpc_url_8453',
+        'https://custom-base.example.com'
+      )
+
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+
+      expect(result).toEqual([
+        { chainId: 1, rpcUrl: 'https://eth-mainnet.example.com' },
+        { chainId: 8453, rpcUrl: 'https://custom-base.example.com' },
+        { chainId: 42161, rpcUrl: 'https://arbitrum-mainnet.example.com' },
+      ])
+    })
+
+    test('only overrides matching chainIds, leaves others unchanged', () => {
+      db.prepare('INSERT INTO configs (key, value) VALUES (?, ?)').run(
+        'rpc_url_1',
+        'https://custom-eth.example.com'
+      )
+
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+
+      expect(result[0]).toEqual({
+        chainId: 1,
+        rpcUrl: 'https://custom-eth.example.com',
+      })
+      expect(result[1]).toEqual({
+        chainId: 8453,
+        rpcUrl: 'https://base-mainnet.example.com',
+      })
+      expect(result[2]).toEqual({
+        chainId: 42161,
+        rpcUrl: 'https://arbitrum-mainnet.example.com',
+      })
+    })
+
+    test('handles multiple DB overrides', () => {
+      const insert = db.prepare(
+        'INSERT INTO configs (key, value) VALUES (?, ?)'
+      )
+      insert.run('rpc_url_1', 'https://custom-eth.example.com')
+      insert.run('rpc_url_42161', 'https://custom-arb.example.com')
+
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+
+      expect(result).toEqual([
+        { chainId: 1, rpcUrl: 'https://custom-eth.example.com' },
+        { chainId: 8453, rpcUrl: 'https://base-mainnet.example.com' },
+        { chainId: 42161, rpcUrl: 'https://custom-arb.example.com' },
+      ])
+    })
+
+    test('ignores invalid DB keys (non-numeric chainId)', () => {
+      db.prepare('INSERT INTO configs (key, value) VALUES (?, ?)').run(
+        'rpc_url_not_a_number',
+        'https://invalid.example.com'
+      )
+
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+
+      expect(result).toEqual(yamlChainRpcs)
+    })
+
+    test('ignores empty DB values', () => {
+      db.prepare('INSERT INTO configs (key, value) VALUES (?, ?)').run(
+        'rpc_url_8453',
+        ''
+      )
+
+      // Empty value rows are still returned by the LIKE query, so
+      // dbRpcConfigs.length > 0, but the row.value check filters them out.
+      const result = mergeChainRpcsWithDbOverrides(db, yamlChainRpcs)
+
+      expect(result).toEqual(yamlChainRpcs)
+    })
+  })
+
+  describe('getRpcUrl Logic', () => {
+    test('returns yaml default when no DB override exists', () => {
+      const result = getRpcUrl(db, yamlChainRpcs, 8453)
+      expect(result).toEqual({
+        rpcUrl: 'https://base-mainnet.example.com',
+        isCustom: false,
+      })
+    })
+
+    test('returns DB value with isCustom=true when override exists', () => {
+      db.prepare('INSERT INTO configs (key, value) VALUES (?, ?)').run(
+        'rpc_url_8453',
+        'https://custom-base.example.com'
+      )
+
+      const result = getRpcUrl(db, yamlChainRpcs, 8453)
+      expect(result).toEqual({
+        rpcUrl: 'https://custom-base.example.com',
+        isCustom: true,
+      })
+    })
+
+    test('returns empty string when chainId not in yaml or DB', () => {
+      const result = getRpcUrl(db, yamlChainRpcs, 99999)
+      expect(result).toEqual({ rpcUrl: '', isCustom: false })
+    })
+  })
+
+  describe('setRpcUrl Logic', () => {
+    test('saves rpc_url_{chainId} to configs table', () => {
+      const result = setRpcUrl(db, 8453, 'https://custom-base.example.com')
+
+      expect(result).toEqual({ success: true })
+
+      const row = db
+        .prepare('SELECT value FROM configs WHERE key = ?')
+        .get('rpc_url_8453') as { value: string }
+      expect(row.value).toBe('https://custom-base.example.com')
+    })
+
+    test('overwrites existing DB value', () => {
+      setRpcUrl(db, 8453, 'https://first.example.com')
+      setRpcUrl(db, 8453, 'https://second.example.com')
+
+      const row = db
+        .prepare('SELECT value FROM configs WHERE key = ?')
+        .get('rpc_url_8453') as { value: string }
+      expect(row.value).toBe('https://second.example.com')
+
+      const count = db
+        .prepare("SELECT COUNT(*) as cnt FROM configs WHERE key = 'rpc_url_8453'")
+        .get() as { cnt: number }
+      expect(count.cnt).toBe(1)
+    })
+  })
+
+  describe('resetRpcUrl Logic', () => {
+    test('removes rpc_url_{chainId} from configs table', () => {
+      setRpcUrl(db, 8453, 'https://custom-base.example.com')
+
+      const result = resetRpcUrl(db, 8453)
+
+      expect(result).toEqual({ success: true })
+
+      const row = db
+        .prepare('SELECT value FROM configs WHERE key = ?')
+        .get('rpc_url_8453')
+      expect(row).toBeUndefined()
+    })
+
+    test('no error when key does not exist', () => {
+      const result = resetRpcUrl(db, 99999)
+      expect(result).toEqual({ success: true })
+    })
+  })
+})


### PR DESCRIPTION
- Restructure Settings page with vertical MUI Tabs (API Key / RPC URL)
- Add RPC URL configuration per chain with DB persistence (overlay: DB > yaml fallback)
- Save triggers immediate provider reload via reloadCore()
- Add Content-Security-Policy to Electron BrowserWindow (no unsafe-eval)
- Add unit tests for overlay merge logic and CSP builder