### PR TITLE
fix(security): allow Google Fonts and HTTP RPC endpoints in CSP

### DIFF
--- a/electron/main/csp.ts
+++ b/electron/main/csp.ts
@@ -10,19 +10,19 @@ export function buildCsp(isDev: boolean): string {
     return [
       "default-src 'self'",
       "script-src 'self' 'unsafe-eval'",
-      "style-src 'self' 'unsafe-inline'",
-      "font-src 'self' data:",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' data: https://fonts.gstatic.com",
       "img-src 'self' data: https:",
-      "connect-src 'self' http://localhost:3000 ws://localhost:3000 ws: wss: https:",
+      "connect-src 'self' http://localhost:3000 ws://localhost:3000 http: https: ws: wss:",
     ].join('; ')
   }
 
   return [
     "default-src 'self' app:",
     "script-src 'self' app:",
-    "style-src 'self' 'unsafe-inline' app:",
-    "font-src 'self' data: app:",
+    "style-src 'self' 'unsafe-inline' app: https://fonts.googleapis.com",
+    "font-src 'self' data: app: https://fonts.gstatic.com",
     "img-src 'self' data: https: app:",
-    "connect-src 'self' app: ws: wss: https:",
+    "connect-src 'self' app: http: https: ws: wss:",
   ].join('; ')
 }

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -34,14 +34,19 @@ describe('buildCsp', () => {
       expect(csp).toMatch(/script-src\s+'self'\s+'unsafe-eval'/)
     })
 
+    it('allows Google Fonts in style-src and font-src', () => {
+      expect(csp).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/)
+      expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/)
+    })
+
+    it('allows http: and https: for connect-src (RPC endpoints)', () => {
+      expect(csp).toMatch(/connect-src[^;]*http:/)
+      expect(csp).toMatch(/connect-src[^;]*https:/)
+    })
+
     it('allows data: URIs for fonts and images', () => {
       expect(csp).toMatch(/font-src[^;]*data:/)
       expect(csp).toMatch(/img-src[^;]*data:/)
-    })
-
-    it('allows https: for connect-src and img-src', () => {
-      expect(csp).toMatch(/connect-src[^;]*https:/)
-      expect(csp).toMatch(/img-src[^;]*https:/)
     })
   })
 
@@ -77,14 +82,19 @@ describe('buildCsp', () => {
       expect(csp).toMatch(/connect-src[^;]*\bwss:/)
     })
 
+    it('allows Google Fonts in style-src and font-src', () => {
+      expect(csp).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/)
+      expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/)
+    })
+
+    it('allows http: and https: for connect-src (RPC endpoints)', () => {
+      expect(csp).toMatch(/connect-src[^;]*http:/)
+      expect(csp).toMatch(/connect-src[^;]*https:/)
+    })
+
     it('allows data: URIs for fonts and images', () => {
       expect(csp).toMatch(/font-src[^;]*data:/)
       expect(csp).toMatch(/img-src[^;]*data:/)
-    })
-
-    it('allows https: for connect-src and img-src', () => {
-      expect(csp).toMatch(/connect-src[^;]*https:/)
-      expect(csp).toMatch(/img-src[^;]*https:/)
     })
   })
 })


### PR DESCRIPTION
- Add fonts.googleapis.com to style-src and fonts.gstatic.com to font-src
- Add http: to connect-src for plain HTTP RPC endpoints (e.g. dev env)